### PR TITLE
Fixed that the enemy/safe biome configs weren't reloaded everytime

### DIFF
--- a/src/main/java/pvpmode/modules/lotr/internal/server/LOTRServerConfigurationImpl.java
+++ b/src/main/java/pvpmode/modules/lotr/internal/server/LOTRServerConfigurationImpl.java
@@ -7,7 +7,6 @@ import net.minecraftforge.common.config.Configuration;
 import pvpmode.api.common.SimpleLogger;
 import pvpmode.api.common.configuration.ConfigurationPropertyKey;
 import pvpmode.api.common.configuration.auto.AutoConfigurationConstants;
-import pvpmode.api.common.utils.Inject;
 import pvpmode.api.common.utils.Process;
 import pvpmode.internal.common.configuration.AutoForgeConfigurationManager;
 import pvpmode.modules.lotr.api.server.LOTRServerConfiguration;
@@ -19,12 +18,6 @@ public class LOTRServerConfigurationImpl extends AutoForgeConfigurationManager i
 
     private final LOTRModCompatibilityModule module;
 
-    @Inject
-    public static final ConfigurationPropertyKey<?> ENEMY_BIOME_OVERRIDES_ENABLED = null;
-
-    @Inject
-    public static final ConfigurationPropertyKey<?> SAFE_BIOME_OVERRIDES_ENABLED = null;
-
     protected LOTRServerConfigurationImpl (Configuration configuration,
         Map<String, ConfigurationPropertyKey<?>> propertyKeys, SimpleLogger logger, LOTRModCompatibilityModule module)
     {
@@ -33,40 +26,29 @@ public class LOTRServerConfigurationImpl extends AutoForgeConfigurationManager i
     }
 
     @Override
-    protected void onPropertyChanged (ConfigurationPropertyKey<?> key, Object oldValue, Object newValue)
-    {
-        super.onPropertyChanged (key, oldValue, newValue);
-
-        if (key == LOTRServerConfigurationImpl.ENEMY_BIOME_OVERRIDES_ENABLED)
-        {
-            if (this.areEnemyBiomeOverridesEnabled ())
-            {
-                module.initEnemyBiomeOverrides ();
-            }
-            else
-            {
-                module.removeEnemyBiomeOverrideCondition ();
-            }
-        }
-        else if (key == LOTRServerConfigurationImpl.SAFE_BIOME_OVERRIDES_ENABLED)
-        {
-            if (this.areSafeBiomeOverridesEnabled ())
-            {
-                module.initSafeBiomeOverrides ();
-            }
-            else
-            {
-                module.removeSafeBiomeOverrideCondition ();
-            }
-        }
-    }
-
-    @Override
     protected void onPropertiesChanged ()
     {
         super.onPropertiesChanged ();
 
         module.initGeneralBiomeOverrides ();
+
+        if (this.areEnemyBiomeOverridesEnabled ())
+        {
+            module.initEnemyBiomeOverrides ();
+        }
+        else
+        {
+            module.removeEnemyBiomeOverrideCondition ();
+        }
+
+        if (this.areSafeBiomeOverridesEnabled ())
+        {
+            module.initSafeBiomeOverrides ();
+        }
+        else
+        {
+            module.removeSafeBiomeOverrideCondition ();
+        }
 
         logger.info ("PvP mode overrides for LOTR biomes are %s",
             this.areEnemyBiomeOverridesEnabled () || this.areSafeBiomeOverridesEnabled () ? "enabled"


### PR DESCRIPTION
It's an internal pre-release bug, so no changelog entry is necessary.