### PR TITLE
Fixed that the invalid value message for /pvpconfig set was broken

### DIFF
--- a/src/main/java/pvpmode/internal/server/command/PvPCommandConfig.java
+++ b/src/main/java/pvpmode/internal/server/command/PvPCommandConfig.java
@@ -617,7 +617,8 @@ public class PvPCommandConfig extends AbstractPvPCommand
 
         if (!castKey.isValidValue (newValue))
             throw new CommandException (
-                String.format ("\"%s§r\" is not a valid value for \"%s\"", newValue,
+                String.format ("\"%s\" is not a valid value for \"%s\"",
+                    new ChatComponentText (newValue.toString ()).getUnformattedText (),
                     getDisplayName (manager, castKey)));
 
         manager.setProperty (castKey, newValue);


### PR DESCRIPTION
This is an internal pre-release bug, so no changelog entry is needed.