### PR TITLE
Fixed a crash when the PvP Mode Mod was loaded without the LOTR Mod

### DIFF
--- a/src/main/java/pvpmode/api/common/configuration/auto/AutoConfigurationConstants.java
+++ b/src/main/java/pvpmode/api/common/configuration/auto/AutoConfigurationConstants.java
@@ -17,5 +17,6 @@ public interface AutoConfigurationConstants
     public static final String INTERNAL_NAME_PROPERTY_KEY = "internal_name";
     public static final String COMMENT_FILE_PROPERTY_KEY = "comments";
     public static final String PROPERTY_GENERATOR_TYPE_PROPERTY_KEY = "type";
+    public static final String MANUAL_PROCESSING_PROPERTY_KEY = "manual_processing";
 
 }

--- a/src/main/java/pvpmode/api/common/configuration/auto/AutoConfigurationManager.java
+++ b/src/main/java/pvpmode/api/common/configuration/auto/AutoConfigurationManager.java
@@ -6,7 +6,12 @@ import pvpmode.api.common.configuration.ConfigurationManager;
  * The interface for automatically managed configuration managers. That means,
  * that the configuration properties can be specified via annotated methods of
  * the interface, and the auto configuration environment will take care of the
- * correct handling of these properties.
+ * correct handling of these properties. The manager can be annotated with the
+ * {@link pvpmode.api.common.utils.Process} annotation, so it'll be processed
+ * automatically via the auto configuration system. If the property
+ * {@link AutoConfigurationConstants#MANUAL_PROCESSING_PROPERTY_KEY} is used
+ * with the value \"true\", the manager has to be submitted manually to the
+ * processing instance.
  * 
  * @author CraftedMods
  *

--- a/src/main/java/pvpmode/internal/common/configuration/AutoConfigurationCreator.java
+++ b/src/main/java/pvpmode/internal/common/configuration/AutoConfigurationCreator.java
@@ -104,31 +104,29 @@ public class AutoConfigurationCreator
         {
             Map<String, String> properties = PvPCommonUtils.getPropertiesFromProcessedClass (classToProcess);
 
+            String pid = properties.get (AutoConfigurationConstants.PID_PROPERTY_KEY);
             String manualProcessingValue = properties
                 .get (AutoConfigurationConstants.MANUAL_PROCESSING_PROPERTY_KEY);
 
-            if (manualProcessingValue != null && manualProcessingValue.equalsIgnoreCase ("true"))
+            if (pid != null)
             {
-                continue; // Don't process the class
-            }
-            else
-            {
-                // No manual processing, proceed
-
-                if (properties.containsKey (AutoConfigurationConstants.PID_PROPERTY_KEY))
+                if (manualProcessingValue == null || manualProcessingValue.equalsIgnoreCase ("false"))
                 {
-                    String pid = properties.get (AutoConfigurationConstants.PID_PROPERTY_KEY);
+                    // No manual processing
                     if (!classesToProcessByPid.containsKey (pid))
                     {
                         classesToProcessByPid.put (pid, new HashSet<> ());
                     }
                     classesToProcessByPid.get (pid).add (classToProcess);
-
-                    if (manualProcessingValue != null && !manualProcessingValue.equalsIgnoreCase ("false"))
-                        logger.error (
-                            "The value \"%s\" of the manual processing property of the configuration manager \"%s\" is not a boolean value. The property is assumed to be false.",
-                            manualProcessingValue, classToProcess.getName ());
                 }
+                else if (!manualProcessingValue.equalsIgnoreCase ("true"))
+                {
+                    // The value for the manual processing was specified, but neither true nor false
+                    logger.error (
+                        "The value \"%s\" of the manual processing property of the configuration manager \"%s\" is not a boolean value. The property is assumed to be false.",
+                        manualProcessingValue, classToProcess.getName ());
+                }
+
             }
 
         }

--- a/src/main/java/pvpmode/internal/common/configuration/AutoConfigurationCreator.java
+++ b/src/main/java/pvpmode/internal/common/configuration/AutoConfigurationCreator.java
@@ -123,7 +123,7 @@ public class AutoConfigurationCreator
                 {
                     // The value for the manual processing was specified, but neither true nor false
                     logger.error (
-                        "The value \"%s\" of the manual processing property of the configuration manager \"%s\" is not a boolean value. The property is assumed to be false.",
+                        "The value \"%s\" of the manual processing property of the configuration manager \"%s\" is not a boolean value. The configuration manager won't be processed.",
                         manualProcessingValue, classToProcess.getName ());
                 }
 

--- a/src/main/java/pvpmode/modules/enderio/api/server/EnderIOServerConfiguration.java
+++ b/src/main/java/pvpmode/modules/enderio/api/server/EnderIOServerConfiguration.java
@@ -5,8 +5,10 @@ import pvpmode.api.common.configuration.auto.*;
 import pvpmode.api.common.utils.Process;
 import pvpmode.api.server.configuration.ServerConfiguration;
 
-@Process(properties = AutoConfigurationConstants.PID_PROPERTY_KEY + "="
-    + EnderIOServerConfiguration.ENDER_IO_SERVER_CONFIG_PID)
+@Process(properties =
+{AutoConfigurationConstants.PID_PROPERTY_KEY + "="
+    + EnderIOServerConfiguration.ENDER_IO_SERVER_CONFIG_PID,
+    AutoConfigurationConstants.MANUAL_PROCESSING_PROPERTY_KEY + "=true"})
 public interface EnderIOServerConfiguration extends ConfigurationManager
 {
 

--- a/src/main/java/pvpmode/modules/enderio/internal/server/EnderIOCompatibilityModule.java
+++ b/src/main/java/pvpmode/modules/enderio/internal/server/EnderIOCompatibilityModule.java
@@ -40,6 +40,10 @@ public class EnderIOCompatibilityModule extends AbstractCompatibilityModule impl
 
         config = this.createConfiguration (configFile ->
         {
+            PvPMode.proxy.getAutoConfigManager ().processConfigurationManager (EnderIOServerConfiguration.class,
+                EnderIOServerConfiguration.ENDER_IO_SERVER_CONFIG_PID);
+            PvPMode.proxy.getAutoConfigManager ().processConfigurationManager (EnderIOServerConfigurationImpl.class,
+                EnderIOServerConfiguration.ENDER_IO_SERVER_CONFIG_PID);
             return new EnderIOServerConfigurationImpl (configFile, PvPMode.proxy.getAutoConfigManager ()
                 .getGeneratedKeys ().get (EnderIOServerConfiguration.ENDER_IO_SERVER_CONFIG_PID), logger);
         });

--- a/src/main/java/pvpmode/modules/enderio/internal/server/EnderIOServerConfigurationImpl.java
+++ b/src/main/java/pvpmode/modules/enderio/internal/server/EnderIOServerConfigurationImpl.java
@@ -11,8 +11,10 @@ import pvpmode.api.common.utils.Process;
 import pvpmode.internal.common.configuration.AutoForgeConfigurationManager;
 import pvpmode.modules.enderio.api.server.EnderIOServerConfiguration;
 
-@Process(properties = AutoConfigurationConstants.PID_PROPERTY_KEY + "="
-    + EnderIOServerConfiguration.ENDER_IO_SERVER_CONFIG_PID)
+@Process(properties =
+{AutoConfigurationConstants.PID_PROPERTY_KEY + "="
+    + EnderIOServerConfiguration.ENDER_IO_SERVER_CONFIG_PID,
+    AutoConfigurationConstants.MANUAL_PROCESSING_PROPERTY_KEY + "=true"})
 public class EnderIOServerConfigurationImpl extends AutoForgeConfigurationManager
     implements EnderIOServerConfiguration
 {

--- a/src/main/java/pvpmode/modules/lotr/api/server/LOTRServerConfiguration.java
+++ b/src/main/java/pvpmode/modules/lotr/api/server/LOTRServerConfiguration.java
@@ -12,8 +12,10 @@ import pvpmode.api.common.utils.Process;
 import pvpmode.api.server.configuration.ServerConfiguration;
 import pvpmode.modules.lotr.api.common.LOTRCommonUtils;
 
-@Process(properties = AutoConfigurationConstants.PID_PROPERTY_KEY + "="
-    + LOTRServerConfiguration.LOTR_SERVER_CONFIG_PID)
+@Process(properties =
+{AutoConfigurationConstants.PID_PROPERTY_KEY + "="
+    + LOTRServerConfiguration.LOTR_SERVER_CONFIG_PID,
+    AutoConfigurationConstants.MANUAL_PROCESSING_PROPERTY_KEY + "=true"})
 public interface LOTRServerConfiguration extends ConfigurationManager
 {
 

--- a/src/main/java/pvpmode/modules/lotr/internal/server/LOTRModCompatibilityModule.java
+++ b/src/main/java/pvpmode/modules/lotr/internal/server/LOTRModCompatibilityModule.java
@@ -52,6 +52,10 @@ public class LOTRModCompatibilityModule extends AbstractCompatibilityModule impl
 
         config = this.createConfiguration (configFile ->
         {
+            PvPMode.proxy.getAutoConfigManager ().processConfigurationManager (LOTRServerConfiguration.class,
+                LOTRServerConfiguration.LOTR_SERVER_CONFIG_PID);
+            PvPMode.proxy.getAutoConfigManager ().processConfigurationManager (LOTRServerConfigurationImpl.class,
+                LOTRServerConfiguration.LOTR_SERVER_CONFIG_PID);
             return new LOTRServerConfigurationImpl (configFile, PvPMode.instance.getServerProxy ()
                 .getAutoConfigManager ().getGeneratedKeys ().get (LOTRServerConfiguration.LOTR_SERVER_CONFIG_PID),
                 logger, this);

--- a/src/main/java/pvpmode/modules/lotr/internal/server/LOTRServerConfigurationImpl.java
+++ b/src/main/java/pvpmode/modules/lotr/internal/server/LOTRServerConfigurationImpl.java
@@ -16,8 +16,10 @@ import pvpmode.api.common.utils.Process;
 import pvpmode.internal.common.configuration.AutoForgeConfigurationManager;
 import pvpmode.modules.lotr.api.server.LOTRServerConfiguration;
 
-@Process(properties = AutoConfigurationConstants.PID_PROPERTY_KEY + "="
-    + LOTRServerConfiguration.LOTR_SERVER_CONFIG_PID)
+@Process(properties =
+{AutoConfigurationConstants.PID_PROPERTY_KEY + "="
+    + LOTRServerConfiguration.LOTR_SERVER_CONFIG_PID,
+    AutoConfigurationConstants.MANUAL_PROCESSING_PROPERTY_KEY + "=true"})
 public class LOTRServerConfigurationImpl extends AutoForgeConfigurationManager implements LOTRServerConfiguration
 {
 

--- a/src/main/java/pvpmode/modules/siegeMode/api/server/SiegeModeServerConfiguration.java
+++ b/src/main/java/pvpmode/modules/siegeMode/api/server/SiegeModeServerConfiguration.java
@@ -5,8 +5,10 @@ import pvpmode.api.common.configuration.auto.*;
 import pvpmode.api.common.utils.Process;
 import pvpmode.api.server.configuration.ServerConfiguration;
 
-@Process(properties = AutoConfigurationConstants.PID_PROPERTY_KEY + "="
-    + SiegeModeServerConfiguration.SIEGE_MODE_SERVER_CONFIG_PID)
+@Process(properties =
+{AutoConfigurationConstants.PID_PROPERTY_KEY + "="
+    + SiegeModeServerConfiguration.SIEGE_MODE_SERVER_CONFIG_PID,
+    AutoConfigurationConstants.MANUAL_PROCESSING_PROPERTY_KEY + "=true"})
 public interface SiegeModeServerConfiguration extends ConfigurationManager
 {
 

--- a/src/main/java/pvpmode/modules/siegeMode/internal/server/SiegeModeCompatibilityModule.java
+++ b/src/main/java/pvpmode/modules/siegeMode/internal/server/SiegeModeCompatibilityModule.java
@@ -33,6 +33,10 @@ public class SiegeModeCompatibilityModule extends AbstractCompatibilityModule im
 
         config = this.createConfiguration (configFile ->
         {
+            PvPMode.proxy.getAutoConfigManager ().processConfigurationManager (SiegeModeServerConfiguration.class,
+                SiegeModeServerConfiguration.SIEGE_MODE_SERVER_CONFIG_PID);
+            PvPMode.proxy.getAutoConfigManager ().processConfigurationManager (SiegeModeServerConfigurationImpl.class,
+                SiegeModeServerConfiguration.SIEGE_MODE_SERVER_CONFIG_PID);
             return new SiegeModeServerConfigurationImpl (configFile, PvPMode.proxy.getAutoConfigManager ()
                 .getGeneratedKeys ().get (SiegeModeServerConfiguration.SIEGE_MODE_SERVER_CONFIG_PID), logger);
         });

--- a/src/main/java/pvpmode/modules/siegeMode/internal/server/SiegeModeServerConfigurationImpl.java
+++ b/src/main/java/pvpmode/modules/siegeMode/internal/server/SiegeModeServerConfigurationImpl.java
@@ -11,8 +11,10 @@ import pvpmode.api.common.utils.Process;
 import pvpmode.internal.common.configuration.AutoForgeConfigurationManager;
 import pvpmode.modules.siegeMode.api.server.SiegeModeServerConfiguration;
 
-@Process(properties = AutoConfigurationConstants.PID_PROPERTY_KEY + "="
-    + SiegeModeServerConfiguration.SIEGE_MODE_SERVER_CONFIG_PID)
+@Process(properties =
+{AutoConfigurationConstants.PID_PROPERTY_KEY + "="
+    + SiegeModeServerConfiguration.SIEGE_MODE_SERVER_CONFIG_PID,
+    AutoConfigurationConstants.MANUAL_PROCESSING_PROPERTY_KEY + "=true"})
 public class SiegeModeServerConfigurationImpl extends AutoForgeConfigurationManager
     implements SiegeModeServerConfiguration
 {


### PR DESCRIPTION
Therefore the auto configuration system was changed a bit -
configuration managers can now be processed explicitly, and not
automatically anymore. This will be done for the configuration managers
of compatibility modules - they'll be processed upon loading. 
Because this is something internal, no changelog entry is provided. The bug was introduced with a recent commit, so it doesn't affect `2.0.0-BETA.1` releases.