### PR TITLE
Clientside features

### DIFF
--- a/src/main/java/pvpmode/api/common/network/ClientsideFeatureSupportRequest.java
+++ b/src/main/java/pvpmode/api/common/network/ClientsideFeatureSupportRequest.java
@@ -10,7 +10,7 @@ import pvpmode.PvPMode;
 import pvpmode.api.server.network.ClientsideSupportHandler;
 
 /**
- * A package that is sent, if the client requests clientside support from the
+ * A package that is sent when the client requests clientside support from the
  * server. That means, that the server will send relevant data and game events
  * to the client, so that it can process them. To example the client can be
  * notified about PvP Mode changes, running timers, and so on.

--- a/src/main/java/pvpmode/api/common/network/ClientsideFeatureSupportRequest.java
+++ b/src/main/java/pvpmode/api/common/network/ClientsideFeatureSupportRequest.java
@@ -1,0 +1,146 @@
+package pvpmode.api.common.network;
+
+import java.util.UUID;
+
+import cpw.mods.fml.common.network.ByteBufUtils;
+import cpw.mods.fml.common.network.simpleimpl.*;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.entity.player.EntityPlayerMP;
+import pvpmode.PvPMode;
+import pvpmode.api.server.network.ClientsideSupportHandler;
+
+/**
+ * A package that is sent, if the client requests clientside support from the
+ * server. That means, that the server will send relevant data and game events
+ * to the client, so that it can process them. To example the client can be
+ * notified about PvP Mode changes, running timers, and so on.
+ * 
+ * @author CraftedMods
+ *
+ */
+public class ClientsideFeatureSupportRequest implements IMessage
+{
+
+    /**
+     * The version of the PvP Mode Mod the client uses. Has to be a semantic version
+     * string.
+     */
+    private String pvpModeVersion;
+
+    public ClientsideFeatureSupportRequest ()
+    {
+    }
+
+    public ClientsideFeatureSupportRequest (String pvpModeVersion)
+    {
+        this.pvpModeVersion = pvpModeVersion;
+    }
+
+    @Override
+    public void fromBytes (ByteBuf buf)
+    {
+        pvpModeVersion = ByteBufUtils.readUTF8String (buf);
+    }
+
+    @Override
+    public void toBytes (ByteBuf buf)
+    {
+        ByteBufUtils.writeUTF8String (buf, pvpModeVersion);
+    }
+
+    /**
+     * The answer the server sends to the client after the request. Tells the client
+     * whether it'll be supported.
+     * 
+     * @author CraftedMods
+     *
+     */
+    public static class ClientsideFeatureSupportRequestAnswer implements IMessage
+    {
+
+        /**
+         * Whether the client will be supported
+         */
+        private boolean supported;
+
+        public ClientsideFeatureSupportRequestAnswer ()
+        {
+        }
+
+        public ClientsideFeatureSupportRequestAnswer (boolean supported)
+        {
+            this.supported = supported;
+        }
+
+        @Override
+        public void fromBytes (ByteBuf buf)
+        {
+            supported = buf.readBoolean ();
+        }
+
+        @Override
+        public void toBytes (ByteBuf buf)
+        {
+            buf.writeBoolean (supported);
+        }
+
+    }
+
+    public static class ClientsideFeatureSupportRequestHandler
+        implements IMessageHandler<ClientsideFeatureSupportRequest, ClientsideFeatureSupportRequestAnswer>
+    {
+
+        @Override
+        public ClientsideFeatureSupportRequestAnswer onMessage (ClientsideFeatureSupportRequest message,
+            MessageContext ctx)
+        {
+            EntityPlayerMP player = ctx.getServerHandler ().playerEntity;
+            UUID playerUUID = player.getUniqueID ();
+            ClientsideSupportHandler supportHandler = PvPMode.instance.getServerProxy ().getClientsideSupportHandler ();
+
+            if (!supportHandler.isClientsideSupported (playerUUID))
+            {
+                if (supportHandler.isRemoteVersionSupported (message.pvpModeVersion))
+                {
+                    PvPMode.proxy.getLogger ().info (
+                        "The client of %s requested client-side support and got it - the client's PvP Mode Version (%s) is supported",
+                        player.getDisplayName (), message.pvpModeVersion);
+                    supportHandler.addClientsideSupport (playerUUID);
+                    return new ClientsideFeatureSupportRequestAnswer (true);
+                }
+                {
+                    PvPMode.proxy.getLogger ().info (
+                        "The client of %s requested client-side support, but the client's PvP Mode Version (%s) is not supported",
+                        player.getDisplayName (), message.pvpModeVersion);
+                    return new ClientsideFeatureSupportRequestAnswer (false);
+                }
+            }
+            return null;
+        }
+
+    }
+
+    public static class ClientsideFeatureSupportRequestAnswerHandler
+        implements IMessageHandler<ClientsideFeatureSupportRequestAnswer, ClientsideFeatureSupportRequestAnswer>
+    {
+
+        @Override
+        public ClientsideFeatureSupportRequestAnswer onMessage (ClientsideFeatureSupportRequestAnswer message,
+            MessageContext ctx)
+        {
+            if (message.supported)
+            {
+                PvPMode.proxy.getLogger ().info (
+                    "The server supports the local PvP Mode version - clientside support will be enabled");
+            }
+            else
+            {
+                PvPMode.proxy.getLogger ().warning (
+                    "The server doesn't support the local PvP Mode version - clientside support is disabled");
+            }
+            return null;
+        }
+
+    }
+
+}

--- a/src/main/java/pvpmode/api/server/network/ClientsideSupportHandler.java
+++ b/src/main/java/pvpmode/api/server/network/ClientsideSupportHandler.java
@@ -18,7 +18,7 @@ public interface ClientsideSupportHandler
      * is supported.
      * 
      * @param version
-     *            The client's version
+     *            The remote version
      * @return Whether it's supported
      */
     public boolean isRemoteVersionSupported (String version);

--- a/src/main/java/pvpmode/api/server/network/ClientsideSupportHandler.java
+++ b/src/main/java/pvpmode/api/server/network/ClientsideSupportHandler.java
@@ -1,0 +1,60 @@
+package pvpmode.api.server.network;
+
+import java.util.UUID;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+
+/**
+ * Monitors the clients, that are supported currently. This handler will also
+ * supply the initial data to the client.
+ * 
+ * @author CraftedMods
+ *
+ */
+public interface ClientsideSupportHandler
+{
+    /**
+     * Returns whether the remote version (the client's version) of the PvP Mode Mod
+     * is supported.
+     * 
+     * @param version
+     *            The client's version
+     * @return Whether it's supported
+     */
+    public boolean isRemoteVersionSupported (String version);
+
+    /**
+     * Registers the specified client as supported.
+     * 
+     * @param player
+     *            The UUID of the player
+     */
+    public void addClientsideSupport (UUID player);
+
+    /**
+     * Unregisters the specified client as supported.
+     * 
+     * @param player
+     *            The UUID of the player
+     */
+    public void removeClientsideSupport (UUID player);
+
+    /**
+     * Returns whether the specified client is supported.
+     * 
+     * @param player
+     *            The player's UUID
+     * @return Whether the client is supported
+     */
+    public boolean isClientsideSupported (UUID player);
+
+    /**
+     * Called one time when a supported client connects. Used to broadcast the
+     * packets containing the initial, relevant data to the client.
+     * 
+     * @param player
+     *            The player
+     */
+    public void sendInitialSupportPackages (EntityPlayerMP player);
+
+}

--- a/src/main/java/pvpmode/api/server/network/ClientsideSupportHandler.java
+++ b/src/main/java/pvpmode/api/server/network/ClientsideSupportHandler.java
@@ -19,7 +19,7 @@ public interface ClientsideSupportHandler
      * 
      * @param version
      *            The remote version
-     * @return Whether it's supported
+     * @return Whether the remote version is supported
      */
     public boolean isRemoteVersionSupported (String version);
 

--- a/src/main/java/pvpmode/internal/client/ClientProxy.java
+++ b/src/main/java/pvpmode/internal/client/ClientProxy.java
@@ -2,7 +2,9 @@ package pvpmode.internal.client;
 
 import java.util.*;
 
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.event.*;
+import net.minecraftforge.common.MinecraftForge;
 import pvpmode.api.client.configuration.ClientConfiguration;
 import pvpmode.api.common.configuration.*;
 import pvpmode.internal.client.configuration.ClientConfigurationImpl;
@@ -10,6 +12,8 @@ import pvpmode.internal.common.CommonProxy;
 
 public class ClientProxy extends CommonProxy
 {
+
+    private PvPClientEventHandler eventHandler;
 
     @Override
     public void onPreInit (FMLPreInitializationEvent event) throws Exception
@@ -27,6 +31,11 @@ public class ClientProxy extends CommonProxy
         configuration = new ClientConfigurationImpl (this, forgeConfiguration,
             properties);
         configuration.load ();
+
+        eventHandler = new PvPClientEventHandler ();
+
+        MinecraftForge.EVENT_BUS.register (eventHandler);
+        FMLCommonHandler.instance ().bus ().register (eventHandler);
     }
 
     @Override

--- a/src/main/java/pvpmode/internal/client/PvPClientEventHandler.java
+++ b/src/main/java/pvpmode/internal/client/PvPClientEventHandler.java
@@ -9,11 +9,6 @@ import pvpmode.api.common.network.ClientsideFeatureSupportRequest;
 public class PvPClientEventHandler
 {
 
-    public PvPClientEventHandler ()
-    {
-
-    }
-
     @SubscribeEvent
     public void onPlayerLoggedIn (EntityJoinWorldEvent event)
     {

--- a/src/main/java/pvpmode/internal/client/PvPClientEventHandler.java
+++ b/src/main/java/pvpmode/internal/client/PvPClientEventHandler.java
@@ -1,0 +1,26 @@
+package pvpmode.internal.client;
+
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.event.entity.EntityJoinWorldEvent;
+import pvpmode.PvPMode;
+import pvpmode.api.common.network.ClientsideFeatureSupportRequest;
+
+public class PvPClientEventHandler
+{
+
+    public PvPClientEventHandler ()
+    {
+
+    }
+
+    @SubscribeEvent
+    public void onPlayerLoggedIn (EntityJoinWorldEvent event)
+    {
+        if (event.entity instanceof EntityPlayer)
+        {
+            PvPMode.proxy.getPacketDispatcher ().sendToServer (new ClientsideFeatureSupportRequest (PvPMode.VERSION));
+        }
+    }
+
+}

--- a/src/main/java/pvpmode/internal/client/PvPClientEventHandler.java
+++ b/src/main/java/pvpmode/internal/client/PvPClientEventHandler.java
@@ -4,7 +4,7 @@ import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import pvpmode.PvPMode;
-import pvpmode.api.common.network.ClientsideFeatureSupportRequest;
+import pvpmode.internal.common.network.ClientsideFeatureSupportRequest;
 
 public class PvPClientEventHandler
 {

--- a/src/main/java/pvpmode/internal/common/CommonProxy.java
+++ b/src/main/java/pvpmode/internal/common/CommonProxy.java
@@ -13,12 +13,12 @@ import pvpmode.*;
 import pvpmode.api.common.SimpleLogger;
 import pvpmode.api.common.compatibility.*;
 import pvpmode.api.common.configuration.*;
-import pvpmode.api.common.network.ClientsideFeatureSupportRequest;
-import pvpmode.api.common.network.ClientsideFeatureSupportRequest.*;
 import pvpmode.api.common.version.*;
 import pvpmode.internal.common.compatibility.CompatibilityManagerImpl;
 import pvpmode.internal.common.configuration.*;
 import pvpmode.internal.common.core.PvPModeCore;
+import pvpmode.internal.common.network.ClientsideFeatureSupportRequest;
+import pvpmode.internal.common.network.ClientsideFeatureSupportRequest.*;
 import pvpmode.internal.common.utils.ClassDiscoverer;
 import pvpmode.internal.common.version.VersionCheckerImpl;
 

--- a/src/main/java/pvpmode/internal/common/network/ClientsideFeatureSupportRequest.java
+++ b/src/main/java/pvpmode/internal/common/network/ClientsideFeatureSupportRequest.java
@@ -98,7 +98,7 @@ public class ClientsideFeatureSupportRequest implements IMessage
             UUID playerUUID = player.getUniqueID ();
             ClientsideSupportHandler supportHandler = PvPMode.instance.getServerProxy ().getClientsideSupportHandler ();
 
-            if (!supportHandler.isClientsideSupported (playerUUID))
+            if (!supportHandler.isClientsideSupported (playerUUID)) // If the client hasn't clientside support yet
             {
                 if (supportHandler.isRemoteVersionSupported (message.pvpModeVersion))
                 {
@@ -108,6 +108,7 @@ public class ClientsideFeatureSupportRequest implements IMessage
                     supportHandler.addClientsideSupport (playerUUID);
                     return new ClientsideFeatureSupportRequestAnswer (true);
                 }
+                else
                 {
                     PvPMode.proxy.getLogger ().info (
                         "The client of %s requested client-side support, but the client's PvP Mode Version (%s) is not supported",

--- a/src/main/java/pvpmode/internal/common/network/ClientsideFeatureSupportRequest.java
+++ b/src/main/java/pvpmode/internal/common/network/ClientsideFeatureSupportRequest.java
@@ -1,4 +1,4 @@
-package pvpmode.api.common.network;
+package pvpmode.internal.common.network;
 
 import java.util.UUID;
 

--- a/src/main/java/pvpmode/internal/server/PvPServerEventHandler.java
+++ b/src/main/java/pvpmode/internal/server/PvPServerEventHandler.java
@@ -626,4 +626,10 @@ public class PvPServerEventHandler
         }
     }
 
+    @SubscribeEvent
+    public void onPlayerLoggedOut (PlayerLoggedOutEvent event)
+    {
+        server.clientsideSupportHandler.removeClientsideSupport (event.player.getUniqueID ());
+    }
+
 }

--- a/src/main/java/pvpmode/internal/server/PvPServerEventHandler.java
+++ b/src/main/java/pvpmode/internal/server/PvPServerEventHandler.java
@@ -629,7 +629,7 @@ public class PvPServerEventHandler
     @SubscribeEvent
     public void onPlayerLoggedOut (PlayerLoggedOutEvent event)
     {
-        server.clientsideSupportHandler.removeClientsideSupport (event.player.getUniqueID ());
+        server.getClientsideSupportHandler ().removeClientsideSupport (event.player.getUniqueID ());
     }
 
 }

--- a/src/main/java/pvpmode/internal/server/ServerProxy.java
+++ b/src/main/java/pvpmode/internal/server/ServerProxy.java
@@ -16,11 +16,13 @@ import pvpmode.api.server.compatibility.ServerCompatibilityConstants;
 import pvpmode.api.server.compatibility.events.CombatLoggingHandlerRegistryEvent;
 import pvpmode.api.server.configuration.ServerConfiguration;
 import pvpmode.api.server.log.LogHandlerConstants;
+import pvpmode.api.server.network.ClientsideSupportHandler;
 import pvpmode.api.server.utils.*;
 import pvpmode.internal.common.CommonProxy;
 import pvpmode.internal.server.command.*;
 import pvpmode.internal.server.configuration.ServerConfigurationImpl;
 import pvpmode.internal.server.log.*;
+import pvpmode.internal.server.network.ClientsideSupportHandlerImpl;
 import pvpmode.internal.server.overrides.OverrideManagerImpl;
 import pvpmode.internal.server.utils.*;
 import pvpmode.modules.bukkit.internal.server.BukkitCompatibilityModuleLoader;
@@ -50,6 +52,8 @@ public class ServerProxy extends CommonProxy
 
     private ServerChatUtilsProvider chatUtilsProvider;
     private PvPServerUtilsProvider serverUtilsProvider;
+
+    protected final ClientsideSupportHandler clientsideSupportHandler = new ClientsideSupportHandlerImpl ();
 
     public ServerProxy ()
     {
@@ -195,6 +199,11 @@ public class ServerProxy extends CommonProxy
     {
         return Arrays.asList (pvpCommandInstance, pvpadminCommandInstance, pvpconfigCommandInstance,
             pvphelpCommandInstance, pvplistCommandInstance, soulboundCommandInstance);
+    }
+
+    public ClientsideSupportHandler getClientsideSupportHandler ()
+    {
+        return clientsideSupportHandler;
     }
 
 }

--- a/src/main/java/pvpmode/internal/server/network/ClientsideSupportHandlerImpl.java
+++ b/src/main/java/pvpmode/internal/server/network/ClientsideSupportHandlerImpl.java
@@ -1,0 +1,62 @@
+package pvpmode.internal.server.network;
+
+import java.util.*;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+import pvpmode.PvPMode;
+import pvpmode.api.common.version.SemanticVersion;
+import pvpmode.api.server.network.ClientsideSupportHandler;
+
+/**
+ * The implementation of the clientside support handler
+ * 
+ * @author CraftedMods
+ *
+ */
+public class ClientsideSupportHandlerImpl implements ClientsideSupportHandler
+{
+
+    @Override
+    public boolean isRemoteVersionSupported (String version)
+    {
+        try
+        {
+            SemanticVersion remoteVersion = SemanticVersion.of (version);
+            SemanticVersion localVersion = PvPMode.SEMANTIC_VERSION;
+
+            return remoteVersion.getMajorVersion () == localVersion.getMajorVersion ()
+                && remoteVersion.isPreRelease () == localVersion.isPreRelease ();
+        }
+        catch (IllegalArgumentException e)
+        {
+            return false;
+        }
+    }
+
+    private Set<UUID> supportedPlayers = new HashSet<> ();
+
+    @Override
+    public void addClientsideSupport (UUID player)
+    {
+        supportedPlayers.add (player);
+    }
+
+    @Override
+    public void removeClientsideSupport (UUID player)
+    {
+        supportedPlayers.remove (player);
+    }
+
+    @Override
+    public boolean isClientsideSupported (UUID player)
+    {
+        return supportedPlayers.contains (player);
+    }
+
+    @Override
+    public void sendInitialSupportPackages (EntityPlayerMP player)
+    {
+        // TODO Auto-generated method stub
+    }
+
+}

--- a/src/main/java/pvpmode/internal/server/network/ClientsideSupportHandlerImpl.java
+++ b/src/main/java/pvpmode/internal/server/network/ClientsideSupportHandlerImpl.java
@@ -29,6 +29,7 @@ public class ClientsideSupportHandlerImpl implements ClientsideSupportHandler
         }
         catch (IllegalArgumentException e)
         {
+            // No semantic version
             return false;
         }
     }
@@ -56,7 +57,7 @@ public class ClientsideSupportHandlerImpl implements ClientsideSupportHandler
     @Override
     public void sendInitialSupportPackages (EntityPlayerMP player)
     {
-        // TODO Auto-generated method stub
+        // TODO Currently not used
     }
 
 }


### PR DESCRIPTION
A basic framework for packet-based clientside support (see #44 ). The client sends a packet with the clientside version, and if supported, the server saves the client. The client then will be notified via packets about relevant events and so on. The gear item mechanism will add some clientside features, so that the gear blocking works smooth, and doesn't look that buggy (canceling item-use events only serverside makes it to look so).