### PR TITLE
PvP Mode Mod related playerdata are now accessible for offline players

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 #### Bug fixes:
 * Fixed that previously soulbound items couldn't be stacked with unbound ones after they were unbound
 * Fixed a crash when a player died if `keepInventory` was disabled and if the soulbound feature was enabled
+* Fixed that hired units of players with PvP disabled could be attacked when the player was offline
 
 ### Breaking changes (see UPDATE_INSTRUCTIONS.md):
 * Changed the permission nodes of all commands

--- a/src/main/java/pvpmode/PvPMode.java
+++ b/src/main/java/pvpmode/PvPMode.java
@@ -1,5 +1,7 @@
 package pvpmode;
 
+import java.io.IOException;
+
 import cpw.mods.fml.common.*;
 import cpw.mods.fml.common.Mod.*;
 import cpw.mods.fml.common.event.*;
@@ -43,7 +45,7 @@ public class PvPMode
     }
 
     @EventHandler
-    public void onServerStarting (FMLServerStartingEvent event)
+    public void onServerStarting (FMLServerStartingEvent event) throws IOException
     {
         if (proxy instanceof ServerProxy)
         {

--- a/src/main/java/pvpmode/api/server/compatibility/events/EntityMasterExtractionEvent.java
+++ b/src/main/java/pvpmode/api/server/compatibility/events/EntityMasterExtractionEvent.java
@@ -1,12 +1,13 @@
 package pvpmode.api.server.compatibility.events;
 
+import java.util.UUID;
+
 import cpw.mods.fml.common.eventhandler.Event;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.player.EntityPlayerMP;
 
 /**
  * This event will be fired if PvPMode has to determine the master of an
- * attacking entity.
+ * attacking entity - the master as to be a player.
  *
  * @author CraftedMods
  *
@@ -15,7 +16,7 @@ public class EntityMasterExtractionEvent extends Event
 {
 
     private final Entity entity;
-    private EntityPlayerMP master;
+    private UUID masterUUID;
 
     public EntityMasterExtractionEvent (Entity entity)
     {
@@ -31,19 +32,19 @@ public class EntityMasterExtractionEvent extends Event
     }
 
     /**
-     * Returns the currently determined master
+     * Returns the currently determined master player UUID
      */
-    public EntityPlayerMP getMaster ()
+    public UUID getMasterUUID ()
     {
-        return master;
+        return masterUUID;
     }
 
     /**
-     * Sets the determined master. This will replace the current value.
+     * Sets the determined master UUID. This will replace the current value.
      */
-    public void setMaster (EntityPlayerMP master)
+    public void setMasterUUID (UUID masterUUID)
     {
-        this.master = master;
+        this.masterUUID = masterUUID;
     }
 
 }

--- a/src/main/java/pvpmode/api/server/compatibility/events/OnPvPEvent.java
+++ b/src/main/java/pvpmode/api/server/compatibility/events/OnPvPEvent.java
@@ -1,7 +1,8 @@
 package pvpmode.api.server.compatibility.events;
 
+import java.util.UUID;
+
 import cpw.mods.fml.common.eventhandler.*;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.DamageSource;
 import pvpmode.api.common.EnumPvPMode;
 
@@ -15,29 +16,31 @@ import pvpmode.api.common.EnumPvPMode;
 public class OnPvPEvent extends Event
 {
 
-    private final EntityPlayer attacker;
+    private final UUID attackerUUID;
     private final EnumPvPMode attackerMode;
-    private final EntityPlayer victim;
+    private final UUID victimUUID;
     private final EnumPvPMode victimMode;
     private final float damageAmount;
     private final DamageSource source;
 
-    public OnPvPEvent (EntityPlayer attacker, EnumPvPMode attackerMode, EntityPlayer victim, EnumPvPMode victimMode, float damageAmount, DamageSource source)
+    public OnPvPEvent (UUID attackerUUID, EnumPvPMode attackerMode, UUID victimUUID, EnumPvPMode victimMode,
+        float damageAmount, DamageSource source)
     {
-        this.attacker = attacker;
+        this.attackerUUID = attackerUUID;
         this.attackerMode = attackerMode;
-        this.victim = victim;
+        this.victimUUID = victimUUID;
         this.victimMode = victimMode;
         this.damageAmount = damageAmount;
         this.source = source;
     }
 
     /**
-     * Returns the attacker
+     * Returns the attacker player UUID. The UUID is used because the attacker player could be
+     * offline - for example hired units of offline players can still attack online players and their units.
      */
-    public EntityPlayer getAttacker ()
+    public UUID getAttackerUUID ()
     {
-        return attacker;
+        return attackerUUID;
     }
 
     /**
@@ -49,11 +52,12 @@ public class OnPvPEvent extends Event
     }
 
     /**
-     * Returns the victim
+     * Returns the victim player UUID. The UUID is used because the victim could be
+     * offline - for example hired units of offline players could be attacked.
      */
-    public EntityPlayer getVictim ()
+    public UUID getVictimUUID ()
     {
-        return victim;
+        return victimUUID;
     }
 
     /**

--- a/src/main/java/pvpmode/api/server/compatibility/events/OnPvPLogEvent.java
+++ b/src/main/java/pvpmode/api/server/compatibility/events/OnPvPLogEvent.java
@@ -1,7 +1,8 @@
 package pvpmode.api.server.compatibility.events;
 
+import java.util.UUID;
+
 import cpw.mods.fml.common.eventhandler.*;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.DamageSource;
 
 /**
@@ -15,33 +16,33 @@ import net.minecraft.util.DamageSource;
 public class OnPvPLogEvent extends Event
 {
 
-    private final EntityPlayer attacker;
-    private final EntityPlayer victim;
+    private final UUID attackerUUID;
+    private final UUID victimUUID;
     private final float damageAmount;
     private final DamageSource source;
 
-    public OnPvPLogEvent (EntityPlayer attacker, EntityPlayer victim, float damageAmount, DamageSource source)
+    public OnPvPLogEvent (UUID attackerUUID, UUID victimUUID, float damageAmount, DamageSource source)
     {
-        this.attacker = attacker;
-        this.victim = victim;
+        this.attackerUUID = attackerUUID;
+        this.victimUUID = victimUUID;
         this.damageAmount = damageAmount;
         this.source = source;
     }
 
     /**
-     * Returns the attacker
+     * Returns the attacker player UUID
      */
-    public EntityPlayer getAttacker ()
+    public UUID getAttackerUUID ()
     {
-        return attacker;
+        return attackerUUID;
     }
 
     /**
-     * Returns the victim
+     * Returns the victim player UUID
      */
-    public EntityPlayer getVictim ()
+    public UUID getVictimUUID ()
     {
-        return victim;
+        return victimUUID;
     }
 
     /**

--- a/src/main/java/pvpmode/api/server/log/AbstractFileCombatLogHandler.java
+++ b/src/main/java/pvpmode/api/server/log/AbstractFileCombatLogHandler.java
@@ -5,6 +5,13 @@ import java.nio.file.*;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
+import com.mojang.authlib.GameProfile;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.management.PlayerProfileCache;
+import pvpmode.api.server.utils.PvPServerUtils;
+
 /**
  * A basic pvp logging module which supports files which are rotated every time
  * the server starts. You can use this as superclass for logging modules which
@@ -74,6 +81,20 @@ public abstract class AbstractFileCombatLogHandler implements CombatLogHandler
         }
         while (Files.exists (result));
         return result;
+    }
+
+    protected String getUsername (UUID uuid)
+    {
+        PlayerProfileCache cache = MinecraftServer.getServer ().func_152358_ax ();
+
+        EntityPlayerMP player = PvPServerUtils.getPlayer (uuid);
+
+        if (player != null)
+            return player.getDisplayName ();
+
+        GameProfile profile = cache.func_152652_a (uuid);
+
+        return (profile != null ? profile.getName () : uuid.toString ()) + " (offline)";
     }
 
     @Override

--- a/src/main/java/pvpmode/api/server/log/CombatLogHandler.java
+++ b/src/main/java/pvpmode/api/server/log/CombatLogHandler.java
@@ -1,14 +1,13 @@
 package pvpmode.api.server.log;
 
 import java.nio.file.Path;
-import java.util.Date;
+import java.util.*;
 
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.DamageSource;
 
 /**
  * A handler for combat logging. If a player or an unit of this player attacks
- * another player, the mod can log this event. To support multiple logging
+ * another player (or unit of that player), the mod can log this event. To support multiple logging
  * targets (files, different file formats, SQL, E-Mail, ...) the combat logging
  * system uses modules which handle this logging - combat log handlers. Users
  * can activate or deactivate all registered modules via the configuration file.
@@ -31,16 +30,18 @@ public interface CombatLogHandler
      *
      * @param date
      *            The current date and time
-     * @param attacker
-     *            The player which initiated the attack
-     * @param victim
-     *            The player who was attacked
+     * @param attackerUUID
+     *            The UUID of the player which initiated the attack (or owned the
+     *            entity that initiated it)
+     * @param victimUUID
+     *            The UUID of the player who was attacked (or owned the entity that
+     *            was attacked)
      * @param damageAmount
      *            The amount of damage which was dealt
      * @param damageSource
      *            The damage source
      */
-    public void log (Date date, EntityPlayer attacker, EntityPlayer victim, float damageAmount,
+    public void log (Date date, UUID attackerUUID, UUID victimUUID, float damageAmount,
         DamageSource damageSource);
 
     /**

--- a/src/main/java/pvpmode/internal/server/PvPDataManager.java
+++ b/src/main/java/pvpmode/internal/server/PvPDataManager.java
@@ -1,0 +1,174 @@
+package pvpmode.internal.server;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.*;
+
+import net.minecraft.entity.player.*;
+import net.minecraft.nbt.*;
+import pvpmode.api.common.utils.PvPCommonUtils;
+import pvpmode.api.server.PvPData;
+import pvpmode.api.server.utils.PvPServerUtils;
+
+public class PvPDataManager
+{
+
+    private final ServerProxy server;
+    private Path playerDataRootDir;
+
+    private final Map<UUID, PvPDataImpl> playerData = new HashMap<> ();
+
+    public PvPDataManager (ServerProxy server)
+    {
+        this.server = server;
+    }
+
+    public void onServerStarting () throws IOException
+    {
+        playerDataRootDir = server.getWorldDataFolder ().resolve ("playerdata");
+
+        Files.createDirectories (playerDataRootDir);
+    }
+
+    public void onLogin (EntityPlayer player)
+    {
+        loadPlayerData (player.getUniqueID (), compatibilityPatch (player));
+        setCacheData (player);
+    }
+
+    public void onLogout (EntityPlayer player)
+    {
+        setCacheData (player);
+    }
+
+    private void setCacheData (EntityPlayer player)
+    {
+        PvPDataImpl data = (PvPDataImpl) getPlayerData (player);
+
+        data.setCanFlyCache (PvPServerUtils.canFly (player));
+        data.setCreativeCache (PvPCommonUtils.isCreativeMode (player));
+    }
+
+    public PvPData getPlayerData (EntityPlayer player)
+    {
+        return getPlayerData (player.getUniqueID ());
+    }
+
+    public PvPData getPlayerData (UUID playerUUID)
+    {
+        if (!playerData.containsKey (playerUUID))
+        {
+            playerData.put (playerUUID, this.loadPlayerData (playerUUID, null));
+        }
+        return playerData.get (playerUUID);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void saveAndClearData ()
+    {
+        playerData.forEach (this::savePlayerData);
+        Collection<UUID> presentPlayers = new HashSet<> ();
+        ((Collection<EntityPlayerMP>) server.getServerConfigurationManager ().playerEntityList)
+            .forEach (player -> presentPlayers.add (player.getUniqueID ()));
+        playerData.keySet ().removeIf (uuid -> !presentPlayers.contains (uuid));
+    }
+
+    private PvPDataImpl loadPlayerData (UUID playerUUID, NBTTagCompound compatibilityTag)
+    {
+        Path playerDataFile = getPlayerDataFile (playerUUID);
+        NBTTagCompound pvpDataTag = compatibilityTag != null ? compatibilityTag : new NBTTagCompound ();
+        boolean shouldBeSaved = false;
+
+        if (!Files.exists (playerDataFile) || compatibilityTag != null)
+        {
+            shouldBeSaved = true;
+        }
+        else
+        {
+            try
+            {
+                pvpDataTag = CompressedStreamTools.read (playerDataFile.toFile ());
+            }
+            catch (IOException e)
+            {
+                server.getLogger ().errorThrowable ("Couldn't load the playerdata for the player \"%s\"", e,
+                    playerUUID);
+            }
+        }
+
+        PvPDataImpl data = new PvPDataImpl (pvpDataTag, playerUUID);
+
+        if (shouldBeSaved)
+        {
+            savePlayerData (playerUUID, data);
+        }
+
+        return data;
+    }
+
+    private static final String PVP_DATA_NBT_KEY = "PvPData";
+
+    private NBTTagCompound compatibilityPatch (EntityPlayer player)
+    {
+        NBTTagCompound data = player.getEntityData ();
+        NBTTagCompound persistent;
+
+        if (data.hasKey (EntityPlayer.PERSISTED_NBT_TAG))
+        {
+            persistent = data.getCompoundTag (EntityPlayer.PERSISTED_NBT_TAG);
+
+            if (persistent.hasKey (PVP_DATA_NBT_KEY))
+            {
+                NBTTagCompound ret = persistent.getCompoundTag (PVP_DATA_NBT_KEY);
+                persistent.removeTag (PVP_DATA_NBT_KEY);
+                server.getLogger ().info ("Converted the old PvP Mode Mod player data of \"%s\" to the new format",
+                    player.getDisplayName ());
+                return ret;
+            }
+        }
+
+        return null;
+
+    }
+
+    private void savePlayerData (UUID playerUUID, PvPDataImpl playerData)
+    {
+        Path playerDataFile = getPlayerDataFile (playerUUID);
+
+        boolean newFileCreated = false;
+
+        if (!Files.exists (playerDataFile))
+        {
+            try
+            {
+                Files.createFile (playerDataFile);
+                newFileCreated = true;
+            }
+            catch (IOException e)
+            {
+                server.getLogger ().errorThrowable ("Couldn't create the player data file \"%s\"", e,
+                    playerDataFile.toString ());
+            }
+        }
+
+        try
+        {
+            // Only save if the player data did change or were created for the first time
+            if (newFileCreated || playerData.hasChanged ())
+            {
+                CompressedStreamTools.write (playerData.getStorageTag (), playerDataFile.toFile ());
+            }
+        }
+        catch (IOException e)
+        {
+            server.getLogger ().errorThrowable ("Couldn't save the player data file \"%s\"", e,
+                playerDataFile.toString ());
+        }
+    }
+
+    private Path getPlayerDataFile (UUID playerUUID)
+    {
+        return playerDataRootDir.resolve (playerUUID.toString () + ".dat");
+    }
+
+}

--- a/src/main/java/pvpmode/internal/server/log/CSVCombatLogHandler.java
+++ b/src/main/java/pvpmode/internal/server/log/CSVCombatLogHandler.java
@@ -2,9 +2,8 @@ package pvpmode.internal.server.log;
 
 import java.nio.file.Path;
 import java.text.DateFormat;
-import java.util.Date;
+import java.util.*;
 
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.DamageSource;
 import pvpmode.PvPMode;
 import pvpmode.api.server.log.*;
@@ -33,13 +32,13 @@ public class CSVCombatLogHandler extends AbstractFileCombatLogHandler
     }
 
     @Override
-    public void log (Date date, EntityPlayer attacker, EntityPlayer victim, float damageAmount,
+    public void log (Date date, UUID attackerUUID, UUID victimUUID, float damageAmount,
         DamageSource damageSource)
     {
         writer.println (String.format ("%2$s%1$s%3$s%1$s%4$s%1$s%5$.2f%1$s%6$s",
             getCSVSeparator (),
-            DateFormat.getDateTimeInstance ().format (date), attacker.getDisplayName (),
-            victim.getDisplayName (), damageAmount, damageSource.damageType));
+            DateFormat.getDateTimeInstance ().format (date), getUsername (attackerUUID),
+            getUsername (victimUUID), damageAmount, damageSource.damageType));
 
     }
 

--- a/src/main/java/pvpmode/internal/server/log/CombatLogManagerImpl.java
+++ b/src/main/java/pvpmode/internal/server/log/CombatLogManagerImpl.java
@@ -3,7 +3,6 @@ package pvpmode.internal.server.log;
 import java.nio.file.Path;
 import java.util.*;
 
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.DamageSource;
 import pvpmode.api.server.log.*;
 
@@ -103,30 +102,30 @@ public class CombatLogManagerImpl implements CombatLogManager
     }
 
     /**
-     * This function will be invoked if pvp events occur which should be logged. The
+     * This function will be invoked if PvP events occur which should be logged. The
      * manager will distribute the supplied data to all active handlers.
      *
-     * @param attacker
-     *            The attacking player
-     * @param victim
-     *            The attacked player
+     * @param attackerUUID
+     *            The attacking player UUID
+     * @param victimUUID
+     *            The attacked player UUID
      * @param damageAmount
      *            The amount of damage which was dealt
      * @param damageSource
      *            The damage source
      */
-    public void log (EntityPlayer attacker, EntityPlayer victim, float damageAmount, DamageSource damageSource)
+    public void log (UUID attackerUUID, UUID victimUUID, float damageAmount, DamageSource damageSource)
     {
         this.checkState (!canRegisterHandler);
 
-        Objects.requireNonNull (attacker);
-        Objects.requireNonNull (victim);
+        Objects.requireNonNull (attackerUUID);
+        Objects.requireNonNull (victimUUID);
         Objects.requireNonNull (damageSource);
 
         for (String handlerName : activatedHandlerNames)
         {
-            registeredCombatLogHandlers.get (handlerName).log (Calendar.getInstance ().getTime (), attacker,
-                victim, damageAmount, damageSource);
+            registeredCombatLogHandlers.get (handlerName).log (Calendar.getInstance ().getTime (), attackerUUID,
+                victimUUID, damageAmount, damageSource);
         }
     }
 

--- a/src/main/java/pvpmode/internal/server/log/SimpleCombatLogHandler.java
+++ b/src/main/java/pvpmode/internal/server/log/SimpleCombatLogHandler.java
@@ -1,9 +1,8 @@
 package pvpmode.internal.server.log;
 
 import java.text.DateFormat;
-import java.util.Date;
+import java.util.*;
 
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.DamageSource;
 import pvpmode.api.server.log.*;
 
@@ -21,13 +20,13 @@ public class SimpleCombatLogHandler extends AbstractFileCombatLogHandler
     }
 
     @Override
-    public void log (Date date, EntityPlayer attacker, EntityPlayer victim, float damageAmount,
+    public void log (Date date, UUID attackerUUID, UUID victimUUID, float damageAmount,
         DamageSource damageSource)
     {
         writer.println (String.format (
-            "[%s] %s or a (hired) unit of this player initiated an attack against %s dealing %.2f HP damage of the type %s",
-            DateFormat.getDateTimeInstance ().format (date), attacker.getDisplayName (),
-            victim.getDisplayName (), damageAmount, damageSource.damageType));
+            "[%s] %s or a (hired) unit of them initiated an attack against %s (or a (hired) unit of them) dealing %.2f HP damage of the type %s",
+            DateFormat.getDateTimeInstance ().format (date), getUsername (attackerUUID),
+            getUsername (victimUUID), damageAmount, damageSource.damageType));
 
     }
 

--- a/src/main/java/pvpmode/modules/lotr/internal/server/LOTRModServerCompatibilityModule.java
+++ b/src/main/java/pvpmode/modules/lotr/internal/server/LOTRModServerCompatibilityModule.java
@@ -9,7 +9,6 @@ import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import lotr.common.*;
 import lotr.common.entity.npc.LOTREntityNPC;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.player.*;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.living.LivingSetAttackTargetEvent;
 import pvpmode.PvPMode;
@@ -199,10 +198,10 @@ public class LOTRModServerCompatibilityModule extends LOTRModCommonCompatibility
             LOTREntityNPC npc = (LOTREntityNPC) entity;
             if (npc.hiredNPCInfo.isActive)
             {
-                EntityPlayer master = npc.hiredNPCInfo.getHiringPlayer ();
-                if (master != null)
+                UUID masterUUID = npc.hiredNPCInfo.getHiringPlayerUUID ();
+                if (masterUUID != null)
                 {
-                    event.setMaster ((EntityPlayerMP) master);
+                    event.setMasterUUID (masterUUID);
                 }
             }
         }
@@ -226,8 +225,11 @@ public class LOTRModServerCompatibilityModule extends LOTRModCommonCompatibility
     @SubscribeEvent
     public void onAttackTargetSet (LivingSetAttackTargetEvent event)
     {
-        // Fixes that hired units attack players (they don't cause damage, but move to
-        // them)
+        /*
+         * Fixed that hired units eventually "attack" players with PvP Mode OFF - they
+         * don't cause damage (the PvP Mode Mod prevents that), but still move to them,
+         * which is canceled here.
+         */
         if (event.target != null)
         {
             // The entity needs a target
@@ -236,14 +238,14 @@ public class LOTRModServerCompatibilityModule extends LOTRModCommonCompatibility
                 // It needs to be an hired unit
                 LOTREntityNPC npc = (LOTREntityNPC) event.entityLiving;
 
-                EntityPlayer attackingMaster = PvPServerUtils.getMaster (npc);
-                EntityPlayer targetMaster = PvPServerUtils.getMaster (event.target);
+                UUID attackingMasterUUID = PvPServerUtils.getMaster (npc);
+                UUID targetMasterUUID = PvPServerUtils.getMaster (event.target);
 
-                if (attackingMaster != null && targetMaster != null)
+                if (attackingMasterUUID != null && targetMasterUUID != null)
                 {
                     // The attacking unit and the attacked entity have to be assignable to players
-                    if (PvPServerUtils.getPvPMode (attackingMaster) != EnumPvPMode.ON
-                        || PvPServerUtils.getPvPMode (targetMaster) != EnumPvPMode.ON)
+                    if (PvPServerUtils.getPvPMode (attackingMasterUUID) != EnumPvPMode.ON
+                        || PvPServerUtils.getPvPMode (targetMasterUUID) != EnumPvPMode.ON)
                     {
                         // Cancel the attack target assignment of the PvP mode prevents an attack
                         npc.setAttackTarget (null);

--- a/src/main/java/pvpmode/modules/siegeMode/internal/server/SiegeModeCompatibilityModule.java
+++ b/src/main/java/pvpmode/modules/siegeMode/internal/server/SiegeModeCompatibilityModule.java
@@ -3,6 +3,7 @@ package pvpmode.modules.siegeMode.internal.server;
 import java.nio.file.Path;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraftforge.common.MinecraftForge;
 import pvpmode.PvPMode;
 import pvpmode.api.common.SimpleLogger;
@@ -10,6 +11,7 @@ import pvpmode.api.common.compatibility.*;
 import pvpmode.api.common.configuration.*;
 import pvpmode.api.server.compatibility.events.*;
 import pvpmode.api.server.compatibility.events.PvPListEvent.UnsafeClassification;
+import pvpmode.api.server.utils.PvPServerUtils;
 import pvpmode.modules.siegeMode.api.server.SiegeModeServerConfiguration;
 import siege.common.siege.SiegeDatabase;
 
@@ -57,9 +59,12 @@ public class SiegeModeCompatibilityModule extends AbstractCompatibilityModule im
     @SubscribeEvent
     public void onPvPLog (OnPvPLogEvent event)
     {
-        if (config.isPvPLoggingDuringSiegesDisabled ()
-            && (SiegeDatabase.getActiveSiegeForPlayer (event.getAttacker ()) != null
-                || SiegeDatabase.getActiveSiegeForPlayer (event.getVictim ()) != null))
+        EntityPlayerMP attackerPlayer = PvPServerUtils.getPlayer (event.getAttackerUUID ());
+        EntityPlayerMP victimPlayer = PvPServerUtils.getPlayer (event.getVictimUUID ());
+
+        if (config.isPvPLoggingDuringSiegesDisabled () && attackerPlayer != null && victimPlayer != null
+            && (SiegeDatabase.getActiveSiegeForPlayer (attackerPlayer) != null
+                || SiegeDatabase.getActiveSiegeForPlayer (victimPlayer) != null))
         {
             event.setCanceled (true);
         }


### PR DESCRIPTION
The new playerdata are stored independent of the MC playerdata. This especially fixes #113. A similar construct will be used with Lembas, though more extensible. The playerdata in the old format will be converted to the new one, if necessary.
The PR is larger than I initially thought, but most changes are replacing the player instances with the UUIDs, so it shouldn't be that bad.
As the PvP Mode Mod functions, in certain cases will be called for players that are offline, I had to switch a portion of our utility functions from actual player instances to the UUIDs.
To preserve compatibility with our other code parts (and because it's easier to use) I added for most of them overloaded functions which accept the player instance.